### PR TITLE
Update Go ver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/healx/terraform-provider-circleci
 
-go 1.17
+go 1.19
 
 require (
 	github.com/google/uuid v1.3.0


### PR DESCRIPTION
Our release process picks up the go version from go.mod. The provider appears to build fine locally with go1.19.3 darwin/arm64, so updating the version here should fix the release.