### PR TITLE
Use json encoded input for params to support multiple types

### DIFF
--- a/circleci/resource_circleci_schedule_test.go
+++ b/circleci/resource_circleci_schedule_test.go
@@ -160,8 +160,16 @@ func testAccCheckCircleCIScheduleAttributes_basic(schedule *api.Schedule) resour
 			return fmt.Errorf("Unexpected schedule days of week: %v", schedule.Timetable.DaysOfWeek)
 		}
 
-		if len(schedule.Parameters) != 2 || schedule.Parameters["foo"] != "bar" || schedule.Parameters["branch"] != "master" {
+		if len(schedule.Parameters) != 2 {
 			return fmt.Errorf("Unxepected schedule parameters: %v", schedule.Parameters)
+		}
+
+		if v, ok := schedule.Parameters["branch"].(string); ok && v != "master" {
+			return fmt.Errorf("Unxepected schedule parameter: %v", schedule.Parameters)
+		}
+
+		if v, ok := schedule.Parameters["foo"].(bool); ok && !v {
+			return fmt.Errorf("Unxepected schedule parameter: %v", schedule.Parameters)
 		}
 
 		return nil
@@ -179,10 +187,10 @@ resource "circleci_schedule" "%[3]s" {
     hours_of_day = [14]
     days_of_week = ["MON"]
     use_scheduling_system = true
-    parameters = {
-        foo = "bar"
+    parameters_json = jsonencode({
+        foo = true
         branch = "master"
-    }
+    })
 }
 `
 	return fmt.Sprintf(template, organization, project, name)
@@ -214,9 +222,14 @@ func testAccCheckCircleCIScheduleAttributes_update(schedule *api.Schedule) resou
 			return fmt.Errorf("Unexpected schedule days of week: %v", schedule.Timetable.DaysOfWeek)
 		}
 
-		if len(schedule.Parameters) != 1 || schedule.Parameters["branch"] != "main" {
+		if len(schedule.Parameters) != 1 {
 			return fmt.Errorf("Unxepected schedule parameters: %v", schedule.Parameters)
 		}
+
+		if v, ok := schedule.Parameters["branch"].(string); ok && v != "main" {
+			return fmt.Errorf("Unxepected schedule parameter: %v", schedule.Parameters)
+		}
+
 
 		return nil
 	}
@@ -233,9 +246,9 @@ resource "circleci_schedule" "%[3]s" {
     hours_of_day = [19]
     days_of_week = ["TUE"]
     use_scheduling_system = false
-    parameters = {
+    parameters_json = jsonencode({
         branch = "main"
-    }
+    })
 }
 `
 	return fmt.Sprintf(template, organization, project, name)

--- a/website/docs/r/schedule.markdown
+++ b/website/docs/r/schedule.markdown
@@ -24,7 +24,7 @@ resource "circleci_schedule" "schedule" {
   hours_of_day          = [9,23]
   days_of_week          = ["MON", "TUES"]
   use_scheduling_system = false
-  parameters            = { mycoolparam = false}
+  parameters            = jsonencode({ mycoolparam = false })
 }
 ```
 
@@ -40,7 +40,7 @@ The following arguments are supported:
 * `hours_of_day` - (Required) Which hours of the day to trigger a pipeline.
 * `days_of_week` - (Required) Which days of the week (\"MON\" .. \"SUN\") to trigger a pipeline on.
 * `use_scheduling_system` - (Required) Use the scheduled system actor for attribution.
-* `parameters` - (Optional) Pipeline parameters to pass to created pipelines.
+* `parameters_json` - (Optional) JSON encoded pipeline parameters to pass to created pipelines.
 
 ## Attributes Reference
 


### PR DESCRIPTION
`schema.typeMap` in the terraform provider sdk does not support maps with multiple different element types. Instead, we can use a jsonencoded string as input, and do the serialization/deserialization within the provider.